### PR TITLE
A fix to the mandatoryParams

### DIFF
--- a/smpp/pdu/operations.py
+++ b/smpp/pdu/operations.py
@@ -19,6 +19,15 @@ class BindTransmitterResp(PDUResponse):
     commandId = CommandId.bind_transmitter_resp
     mandatoryParams = ['system_id']
     optionalParams = ['sc_interface_version']
+    
+    def __init__(self, seqNum=None, status=CommandStatus.ESME_ROK, **kwargs):
+        """The PDU has no defined body when the status is not 0
+        c.f. 4.1.4. "BIND_RECEIVER_RESP"
+        """
+        if status != CommandStatus.ESME_ROK:
+            self.mandatoryParams = []
+        
+        PDUResponse.__init__(self, seqNum, status, **kwargs)
 
 class BindTransmitter(PDURequest):
     requireAck = BindTransmitterResp
@@ -37,6 +46,15 @@ class BindReceiverResp(PDUResponse):
     commandId = CommandId.bind_receiver_resp
     mandatoryParams = ['system_id']
     optionalParams = ['sc_interface_version']
+    
+    def __init__(self, seqNum=None, status=CommandStatus.ESME_ROK, **kwargs):
+        """The PDU has no defined body when the status is not 0
+        c.f. 4.1.4. "BIND_RECEIVER_RESP"
+        """
+        if status != CommandStatus.ESME_ROK:
+            self.mandatoryParams = []
+        
+        PDUResponse.__init__(self, seqNum, status, **kwargs)
 
 class BindReceiver(PDURequest):
     requireAck = BindReceiverResp
@@ -55,6 +73,15 @@ class BindTransceiverResp(PDUResponse):
     commandId = CommandId.bind_transceiver_resp
     mandatoryParams = ['system_id']
     optionalParams = ['sc_interface_version']
+    
+    def __init__(self, seqNum=None, status=CommandStatus.ESME_ROK, **kwargs):
+        """The PDU has no defined body when the status is not 0
+        c.f. 4.1.4. "BIND_RECEIVER_RESP"
+        """
+        if status != CommandStatus.ESME_ROK:
+            self.mandatoryParams = []
+        
+        PDUResponse.__init__(self, seqNum, status, **kwargs)
     
 class BindTransceiver(PDURequest):
     requireAck = BindTransceiverResp
@@ -89,6 +116,15 @@ class GenericNack(PDUResponse):
 class SubmitSMResp(PDUResponse):
     commandId = CommandId.submit_sm_resp
     mandatoryParams = ['message_id']
+    
+    def __init__(self, seqNum=None, status=CommandStatus.ESME_ROK, **kwargs):
+        """The PDU has no defined body when the status is not 0
+        c.f. 4.4.2. SMPP PDU Definition "SUBMIT_SM_RESP"
+        """
+        if status != CommandStatus.ESME_ROK:
+            self.mandatoryParams = []
+        
+        PDUResponse.__init__(self, seqNum, status, **kwargs)
 
 class SubmitSM(PDUDataRequest):
     requireAck = SubmitSMResp


### PR DESCRIPTION
The PDU body is not returned by the SMSC when the command_status field contains a non-zero value for these PDUs:
- submit_sm_resp
- bind_receiver_resp
- bind_transmitter_resp
- bind_transceiver_resp

An authentication failure would cause the client to consider the connection as corrupt because the PDU body does not exist, this issue is fixed.

Please c.f. to:
- 4.4.2 “SUBMIT_SM_RESP” (page 67)
- 4.1.4 “BIND_RECEIVER_RESP” (page 50)
  from the SMPP 3.4 specification document
