### PR TITLE
smpp relative time parsing improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ _trial_temp
 *.swp
 build/
 dist/
+devpython/
+smpp_time_test.py
+gsm_encoding_test.py
+pdu_encoding_test.py
+pdu_types_test.py
+sm_encoding_test.py

--- a/smpp/pdu/smpp_time.py
+++ b/smpp/pdu/smpp_time.py
@@ -81,10 +81,26 @@ def parse_absolute_time(str):
     timeVal = parse_YYMMDDhhmmss(YYMMDDhhmmss)
     return timeVal.replace(microsecond=microseconds,tzinfo=tzinfo)
     
-def parse_relative_time(str):
-    absT = parse_absolute_time(str[:15] + '+')
-    baseT = parse_YYMMDDhhmmss('000101000000')
-    return SMPPRelativeTime(absT.year - baseT.year, absT.month, absT.day, absT.hour, absT.minute, absT.second)
+def parse_relative_time(dtstr):
+    # example 600 seconds is: '000000001000000R'
+
+    try:
+        year =  int(dtstr[:2])
+        month = int(dtstr[2:4])
+        day = int(dtstr[4:6])
+        hour = int(dtstr[6:8])
+        minute = int(dtstr[8:10])
+        second = int(dtstr[10:12])
+        dsecond = int(dtstr[12:13])
+
+        # According to spec dsecond should be set to 0
+        if dsecond != 0:
+            raise ValueError("SMPP v3.4 spec violation: tenths of second value is %s instead of 0"% dsecond)
+    except IndexError, e:
+        raise ValueError("Error %s : Unable to parse relative Validity Period %s" % e,dtstr)
+
+    return SMPPRelativeTime(year,month,day,hour,minute,second)
+        
     
 def parse_YYMMDDhhmmss(YYMMDDhhmmss):
     return datetime.strptime(YYMMDDhhmmss, YYMMDDHHMMSS_FORMAT)
@@ -111,10 +127,9 @@ def unparse_absolute_time(dt):
 def unparse_relative_time(rel):
     if not isinstance(rel, SMPPRelativeTime):
         raise ValueError("input must be a SMPPRelativeTime")
-    baseT = parse_YYMMDDhhmmss('000101000000')
-    absT = datetime(rel.years + baseT.year, rel.months, rel.days, rel.hours, rel.minutes, rel.seconds)
-    str = unparse_absolute_time(absT)
-    return str[:15] + 'R'
+    relstr = "%s%s%s%s%s%s000R" % (str("%.2d" % rel.years), str("%.2d" % rel.months), str("%.2d" % rel.days), str("%.2d" % rel.hours), str("%.2d" % rel.minutes), str("%.2d" % rel.seconds))
+
+    return relstr
 
 def parse(str):
     """Takes an SMPP time string in.

--- a/smpp/pdu/tests/smpp_time_test.py
+++ b/smpp/pdu/tests/smpp_time_test.py
@@ -47,6 +47,18 @@ class SMPPTimeTest(unittest.TestCase):
         self.assertEquals(29, rel.seconds)
         self.assertEquals(str, smpp_time.unparse(rel))
         
+    def test_parse_relative_mins_only(self):
+        str = '000000001000000R'
+        rel = smpp_time.parse(str)
+        self.assertEquals(smpp_time.SMPPRelativeTime, rel.__class__)
+        self.assertEquals(0, rel.years)
+        self.assertEquals(0, rel.months)
+        self.assertEquals(0, rel.days)
+        self.assertEquals(0, rel.hours)
+        self.assertEquals(10, rel.minutes)
+        self.assertEquals(0, rel.seconds)
+        self.assertEquals(str, smpp_time.unparse(rel))
+
     def test_parse_absolute_no_offset(self):
         str = '070927233429800+'
         dt = smpp_time.parse(str)


### PR DESCRIPTION
parsing PDUs with relative time containing months == 00 or days == 00 would fail as existing code calls parse_absolute_time which depends on datestring which in turn will not accept such values.

Code in parse_relative_time() and unparse_relative_time() has been rewritten to parse smpp relative time correctly.

While doing this, I noticed the use of str as a variable in various places which is a python builtin function! This has been replaced with dtstr in the aforementioned methods and will try to replace all further occurrences in the future.

Finally, a new test case "test_parse_relative_mins_only" has been written in SMPPTimeTest to ensure this bug will not resurface.
